### PR TITLE
Update index.js

### DIFF
--- a/src/components/field/index.js
+++ b/src/components/field/index.js
@@ -20,7 +20,7 @@ import styles from './styles';
 
 function startAnimation(animation, options, callback) {
   Animated
-    .timing(animation, options)
+    .timing(animation, 'useNativeDriver' in options ? options : { ...options, useNativeDriver: false })
     .start(callback);
 }
 


### PR DESCRIPTION
Sets `useNativeDriver: false` as a default `option` for `Animated.timing`. This is also the default value in React Native, but it is now required to be passed explicitly or a warning is issued.